### PR TITLE
Add implicit functor arguments to the implicit environment.

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -79,8 +79,9 @@ exception Error_forward of Location.error
 (* Forward declaration, to be filled in by Typemod.type_module *)
 
 let type_module =
-  ref ((fun env md -> assert false) :
-       Env.t -> Parsetree.module_expr -> Typedtree.module_expr)
+  ref ((fun ?implicit_arity env md -> assert false) :
+       ?implicit_arity:int -> Env.t -> Parsetree.module_expr ->
+       Typedtree.module_expr)
 
 (* Forward declaration, to be filled in by Typemod.type_open *)
 
@@ -2611,7 +2612,11 @@ and type_expect_ ?in_function env sexp ty_expected =
       begin_def ();
       Ident.set_current_time ty.level;
       let context = Typetexp.narrow () in
-      let modl = !type_module env smodl in
+      let implicit_arity = match pmb_implicit with
+        | Nonimplicit -> 0 
+        | Implicit ar -> ar
+      in
+      let modl = !type_module ~implicit_arity env smodl in
       let (id, new_env) =
         Env.enter_module ~implicit_:pmb_implicit name.txt modl.mod_type env in
       Ctype.init_def(Ident.current_time());

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -122,7 +122,9 @@ val report_error: Env.t -> formatter -> error -> unit
  (* Deprecated.  Use Location.{error_of_exn, report_error}. *)
 
 (* Forward declaration, to be filled in by Typemod.type_module *)
-val type_module: (Env.t -> Parsetree.module_expr -> Typedtree.module_expr) ref
+val type_module:
+  (?implicit_arity:int -> Env.t -> Parsetree.module_expr ->
+   Typedtree.module_expr) ref
 (* Forward declaration, to be filled in by Typemod.type_open *)
 val type_open:
     (open_flag -> Env.t -> Location.t -> Longident.t loc -> Path.t * Env.t)

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -16,7 +16,8 @@ open Types
 open Format
 
 val type_module:
-        Env.t -> Parsetree.module_expr -> Typedtree.module_expr
+  ?implicit_arity:int -> Env.t -> Parsetree.module_expr ->
+  Typedtree.module_expr
 val type_structure:
         Env.t -> Parsetree.structure -> Location.t ->
          Typedtree.structure * Types.signature * Env.t


### PR DESCRIPTION
The current implementation has a small asymmetry between the arguments to implicit functors and the implicit arguments to functions:
- implicit arguments to functions are drawn from the implicit environment at application sites and bound in the implicit arguments at definition sites:

``` ocaml
(* val f : (implicit M:S) -> int -> unit *)
let () = f x (* M is resolved in the implicit environment here *)

let f (implicit M:S) x =
  (* M is bound in the implicit environment here *)
  ...
```
- arguments to implicit functors are drawn from the implicit environment at application sites, but not bound in the implicit environment at 

``` ocaml
(* implicit functor F(N:T) : S
   implicit module N : T
   val f : (implicit M:S) -> int -> unit *)
let () = f x (* N is resolved in the implicit environment here *)

implicit functor F(N:T) =
struct
  ... (* N is NOT bound in the implicit environment here *)
```

This turns out to be slightly irritating in practice.  Suppose you have a signature used to define various top-level implicits:

``` ocaml
module type EQ = sig
  type t
  val eq : t -> t -> bool
end

val (=) : (implicit Eq:EQ) -> Eq.t -> Eq.t -> bool
```

You'll typically want to use the top-level definitions when defining implicit functors, but they're not available by default:

``` ocaml
implicit functor Eq_pair(A: EQ) (B: EQ) =
struct
  type t = A.t * B.t
  let eq ((a1, b1) : t) (a2, b2) =
    (* Error! no implicit instance for Eq with type t = A.t *)
    a1 = a2 && b1 = b2
end
```

Of course, you can always add explicit implicit bindings for the functor arguments at the top of the functor body.  However, I'd expect wanting the arguments in the implicit environment to be the more common case by quite some way.

This pull request changes the semantics of implicit functors so that their arguments are added to the implicit environment, as with functions.

(All this is obviated by #12.  If we take _that_ route, the justification for binding implicit module arguments in the implicit environment is even clearer.)
