### PR TITLE
Always generalize implicits before generalization

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1966,6 +1966,7 @@ and type_expect_ ?in_function env sexp ty_expected =
       let case = {c_lhs; c_guard = None; c_rhs = body} in
       let arr = Tarr_implicit id in
       end_def (); (* exit rhs *)
+      Typeimplicit.generalize_implicits (); (* generalize any implicits *)
       end_def (); (* exit implicit binding *)
       let typ = Tarrow (arr, ty_arg, body.exp_type, Cok) in
       rue {

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1633,6 +1633,7 @@ let list_labels env ty =
 
 (* Check that all univars are safe in a type *)
 let check_univars env expans kind exp ty_expected vars =
+  Typeimplicit.generalize_implicits ();
   if expans && not (is_nonexpansive exp) then
     generalize_expansive env exp.exp_type;
   (* need to expand twice? cf. Ctype.unify2 *)
@@ -2032,6 +2033,7 @@ and type_expect_ ?in_function env sexp ty_expected =
       begin_def ();
       let arg = type_exp env sarg in
       end_def ();
+      Typeimplicit.generalize_implicits ();
       if is_nonexpansive arg then generalize arg.exp_type
       else generalize_expansive env arg.exp_type;
       let rec split_cases vc ec = function
@@ -3145,6 +3147,7 @@ and type_label_exp create env loc ty_expected
       begin_def ();
       let arg = type_exp env sarg in
       end_def ();
+      Typeimplicit.generalize_implicits ();
       generalize_expansive env arg.exp_type;
       unify_exp env arg ty_arg;
       check_univars env false "field value" arg label.lbl_arg vars;


### PR DESCRIPTION
Run `generalize_implicits` before any form of generalization. This includes when exiting a function defintion containing an implicit argument because that "generalizes" the types within the implicit argument.
