### PR TITLE
Change the syntax of implicit parameters

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -211,6 +211,10 @@ let lapply p1 p2 =
   then Lapply(p1, p2)
   else raise (Syntaxerr.Error(Syntaxerr.Applicative_path (symbol_rloc())))
 
+let rec mod_ext_apply p1 = function
+  | [] -> p1
+  | p2 :: rest -> Lapply(mod_ext_apply p1 rest, p2)
+
 let exp_of_label lbl pos =
   mkexp (Pexp_ident(mkrhs (Lident(Longident.last lbl)) pos))
 
@@ -691,35 +695,24 @@ module_binding:
 ;
 
 
-implicit_parameter:
-  | LPAREN functor_arg_name COLON module_type RPAREN
-      { (mkrhs $2 2, $4) }
-;
 implicit_parameters:
-    implicit_parameters implicit_parameter
-      { $2 :: $1 }
-  | implicit_parameter
-      { [ $1 ] }
+    /* empty */
+      { [] }
+  | implicit_parameters LBRACE functor_arg_name COLON module_type RBRACE
+      { (mkrhs $3 3, $5) :: $1 }
 ;
-
 implicit_binding:
-    MODULE UIDENT implicit_binding_body post_item_attributes
-    { Mb.implicit_ (mkrhs $2 2) [] $3 ~loc:(symbol_rloc ()) ~attrs:$4 }
-  | FUNCTOR UIDENT implicit_parameters implicit_binding_body post_item_attributes
+    MODULE UIDENT implicit_parameters implicit_binding_body post_item_attributes
     { Mb.implicit_ (mkrhs $2 2) (List.rev $3) $4 ~loc:(symbol_rloc ()) ~attrs:$5 }
 ;
-
 implicit_binding_body:
     EQUAL module_expr
     { $2 }
   | COLON module_type EQUAL module_expr
     { mkmod(Pmod_constraint($4, $2)) }
 ;
-
 implicit_declaration:
-  | MODULE UIDENT implicit_declaration_body post_item_attributes
-    { Md.implicit_ (mkrhs $2 2) [] $3 ~attrs:$4 ~loc:(symbol_rloc()) }
-  | FUNCTOR UIDENT implicit_parameters implicit_declaration_body post_item_attributes
+    MODULE UIDENT implicit_parameters implicit_declaration_body post_item_attributes
     { Md.implicit_ (mkrhs $2 2) (List.rev $3) $4 ~attrs:$5 ~loc:(symbol_rloc()) }
 ;
 implicit_declaration_body:
@@ -1095,9 +1088,9 @@ labeled_simple_pattern:
       { (Parr_labelled (fst $2), None, snd $2) }
   | LABEL simple_pattern
       { (Parr_labelled $1, None, $2) }
-  | LPAREN IMPLICIT UIDENT COLON implicit_module_type RPAREN
-    { (Parr_implicit $3, None,
-       mkpat(Ppat_constraint(mkpat(Ppat_var (mkrhs $3 3)), $5))) }
+  | LBRACE UIDENT COLON implicit_module_type RBRACE
+    { (Parr_implicit $2, None,
+       mkpat(Ppat_constraint(mkpat(Ppat_var (mkrhs $2 2)), $4))) }
   | simple_pattern
       { (Parr_simple, None, $1) }
 ;
@@ -1361,8 +1354,12 @@ label_expr:
       { (Papp_labelled $1, $2) }
   | TILDE label_ident
       { (Papp_labelled (fst $2), snd $2) }
-  | LPAREN IMPLICIT mod_ext_longident RPAREN
-      { let md = mkmod(Pmod_ident (mkrhs $3 3)) in
+  | LBRACE mod_longident RBRACE
+      { let md = mkmod(Pmod_ident (mkrhs $2 2)) in
+        (Papp_implicit, mkexp (Pexp_pack md)) }
+  | LBRACE mod_longident mod_ext_parameters RBRACE
+      { (* FIXME: Identifier location should include parameters *)
+        let md = mkmod(Pmod_ident (mkrhs (mod_ext_apply $2 $3) 2)) in
         (Papp_implicit, mkexp (Pexp_pack md)) }
   | QUESTION label_ident
       { (Papp_optional (fst $2), snd $2) }
@@ -1635,8 +1632,10 @@ type_kind:
       { (Ptype_variant(List.rev $4), $2, None) }
   | EQUAL DOTDOT
       { (Ptype_open, Public, None) }
-  | EQUAL private_flag LBRACE label_declarations opt_semi RBRACE
-      { (Ptype_record(List.rev $4), $2, None) }
+  | EQUAL LBRACE label_declarations opt_semi RBRACE
+      { (Ptype_record(List.rev $3), Public, None) }
+  | EQUAL PRIVATE LBRACE label_declarations opt_semi RBRACE
+      { (Ptype_record(List.rev $4), Private, None) }
   | EQUAL core_type EQUAL private_flag opt_bar constructor_declarations
       { (Ptype_variant(List.rev $6), $4, Some $2) }
   | EQUAL core_type EQUAL DOTDOT
@@ -1835,8 +1834,8 @@ core_type2:
       { mktyp(Ptyp_arrow(Parr_optional $1 , mkoption $2, $4)) }
   | LIDENT COLON core_type2 MINUSGREATER core_type2
       { mktyp(Ptyp_arrow(Parr_labelled $1, $3, $5)) }
-  | LPAREN IMPLICIT UIDENT COLON implicit_module_type RPAREN MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow(Parr_implicit $3, $5, $8)) }
+  | LBRACE UIDENT COLON implicit_module_type RBRACE MINUSGREATER core_type2
+      { mktyp(Ptyp_arrow(Parr_implicit $2, $4, $7)) }
   | core_type2 MINUSGREATER core_type2
       { mktyp(Ptyp_arrow(Parr_simple, $1, $3)) }
 ;
@@ -2072,6 +2071,10 @@ mod_ext_longident:
     UIDENT                                      { Lident $1 }
   | mod_ext_longident DOT UIDENT                { Ldot($1, $3) }
   | mod_ext_longident LPAREN mod_ext_longident RPAREN { lapply $1 $3 }
+;
+mod_ext_parameters:
+  | LPAREN mod_ext_longident RPAREN { [$2] }
+  | mod_ext_parameters LPAREN mod_ext_longident RPAREN { $3 :: $1 }
 ;
 mty_longident:
     ident                                       { Lident $1 }

--- a/testsuite/tests/typing-modular_implicits/arithmetic.ml
+++ b/testsuite/tests/typing-modular_implicits/arithmetic.ml
@@ -1,22 +1,31 @@
 type z = Z
 type 'n s = S of 'n
 
-module type N = sig type n val n : n end
-implicit module Z : N with type n = z = struct type n = z let n = Z end
-implicit functor S(N:N) : N with type n = N.n s = struct type n = N.n
-s let n = S N.n end
+module type N = sig
+  type n
+  val n : n
+end
 
-module type ADD =
-sig
+implicit module Z : N with type n = z = struct
+  type n = z
+  let n = Z
+end
+
+implicit module S {N : N} : N with type n = N.n s = struct
+  type n = N.n s
+  let n = S N.n
+end
+
+module type ADD = sig
   type a and b and c
   val a : a
   val b : b
   val c : c
 end
 
-let add (implicit Add: ADD) (a: Add.a) (b : Add.b) : Add.c = Add.c
+let add {Add : ADD} (a: Add.a) (b : Add.b) : Add.c = Add.c
 
-implicit functor AddZ (B: N) : ADD with type a = z
+implicit module AddZ {B : N} : ADD with type a = z
                                     and type b = B.n
                                     and type c = B.n =
 struct
@@ -24,8 +33,8 @@ struct
   let  a = Z and b = B.n and c = B.n
 end
 
-implicit functor AddS (A: N) (B: N) (Add : ADD with type a = A.n and
-type b = B.n)
+implicit module AddS {A: N} {B: N} {Add : ADD with type a = A.n and
+type b = B.n}
        : ADD with type a = A.n s
               and type b = B.n
               and type c = Add.c s =

--- a/testsuite/tests/typing-modular_implicits/arithmetic.ml.result
+++ b/testsuite/tests/typing-modular_implicits/arithmetic.ml.result
@@ -1,21 +1,21 @@
 
-#                                                                       type z = Z
+#                                                                                         type z = Z
 type 'n s = S of 'n
 module type N = sig type n val n : n end
 implicit module Z : sig type n = z val n : n end
-implicit functor S (N : N) : sig type n = N.n s val n : n end
+implicit module S {N : N} : sig type n = N.n s val n : n end
 module type ADD = sig type a and b and c val a : a val b : b val c : c end
-val add : (implicit Add : ADD) -> Add.a -> Add.b -> Add.c = <fun>
-implicit functor AddZ (B : N) :
+val add : {Add : ADD} -> Add.a -> Add.b -> Add.c = <fun>
+implicit module AddZ {B : N} :
   sig type a = z and b = B.n and c = B.n val a : a val b : b val c : c end
-implicit functor AddS (A : N) (B : N) (Add : sig
-                                               type a = A.n
-                                               and b = B.n
-                                               and c
-                                               val a : a
-                                               val b : b
-                                               val c : c
-                                             end) :
+implicit module AddS {A : N} {B : N} {Add : sig
+                                              type a = A.n
+                                              and b = B.n
+                                              and c
+                                              val a : a
+                                              val b : b
+                                              val c : c
+                                            end} :
   sig
     type a = A.n s
     and b = B.n
@@ -24,80 +24,5 @@ implicit functor AddS (A : N) (B : N) (Add : sig
     val b : b
     val c : c
   end
-#   *     MMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24mMMMMM# 
-  (* Stress Implicitsearch.translpath
-     Resolved code: add (implicit AddS(Z)(Z)(AddZ(Z))) (S Z) Z *)
-  add (S Z) Z
-  ;;
-[24m- : AddS(Z)(Z)(AddZ(Z)).c = S Z
+#   *     - : AddS(Z)(Z)(AddZ(Z)).c = S Z
 # 

--- a/testsuite/tests/typing-modular_implicits/coercion_arity_mismatch.ml
+++ b/testsuite/tests/typing-modular_implicits/coercion_arity_mismatch.ml
@@ -1,4 +1,4 @@
 (* Issue #10 *)
 module type S = sig type t end;;
 module type T = sig type _ t end;;
-let f (x : (implicit X:S) -> X.t) () = (x :> (implicit X:T) -> unit X.t);;
+let f (x : {X : S} -> X.t) () = (x :> {X : T} -> unit X.t);;

--- a/testsuite/tests/typing-modular_implicits/coercion_arity_mismatch.ml.reference
+++ b/testsuite/tests/typing-modular_implicits/coercion_arity_mismatch.ml.reference
@@ -1,8 +1,9 @@
 
 #   module type S = sig type t end
 # module type T = sig type _ t end
-# M# let f (x : (implicit X:S) -> X.t) () = [4m(x :> (implicit X:T) -> unit X.t)[24m;;
-[24mError: Type (implicit X : S) -> X.t is not a subtype of
-         (implicit X : T) -> unit X.t 
+# Characters 32-58:
+  let f (x : {X : S} -> X.t) () = (x :> {X : T} -> unit X.t);;
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type {X : S} -> X.t is not a subtype of {X : T} -> unit X.t 
        Type (module T) is not a subtype of (module S) 
 # 

--- a/testsuite/tests/typing-modular_implicits/coercion_arity_mismatch.ml.result
+++ b/testsuite/tests/typing-modular_implicits/coercion_arity_mismatch.ml.result
@@ -1,8 +1,9 @@
 
 #   module type S = sig type t end
 # module type T = sig type _ t end
-# M# let f (x : (implicit X:S) -> X.t) () = [4m(x :> (implicit X:T) -> unit X.t)[24m;;
-[24mError: Type (implicit X : S) -> X.t is not a subtype of
-         (implicit X : T) -> unit X.t 
+# Characters 32-58:
+  let f (x : {X : S} -> X.t) () = (x :> {X : T} -> unit X.t);;
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type {X : S} -> X.t is not a subtype of {X : T} -> unit X.t 
        Type (module T) is not a subtype of (module S) 
 # 

--- a/testsuite/tests/typing-modular_implicits/implicits.ml
+++ b/testsuite/tests/typing-modular_implicits/implicits.ml
@@ -2,26 +2,35 @@
 module type T = sig type t val x : t end;;
 
 (* BAD *)
-let f () = let x = ref [] in let g (implicit M : T) () = x := [M.x] in ();;
+let f () =
+  let x = ref [] in
+  let g {M : T} () = x := [M.x] in
+    ();;
 
 (* BAD *)
-let f (x : 'a) (implicit M : T) = (x : M.t); ();;
+let f (x : 'a) {M : T} =
+  (x : M.t);
+  ();;
 
 (* OK *)
-let f (implicit M : T) (x : M.t) y = (y : M.t); ();;
+let f {M : T} (x : M.t) y =
+  (y : M.t);
+  ();;
 
 (* OK *)
-let rec f (implicit M : T) (x : M.t) = ();;
+let rec f {M : T} (x : M.t) = ();;
 
 (* OK *)
-let rec f (implicit M : T) (x : M.t) y = (y : M.t); ();;
+let rec f {M : T} (x : M.t) y =
+  (y : M.t);
+  ();;
 
 (* BAD *)
-let f : (implicit M : T) -> 'a -> unit =
-  fun (implicit M : T) (x : M.t) -> ();;
+let f : {M : T} -> 'a -> unit =
+  fun {M : T} (x : M.t) -> ();;
 
 (* OK *)
-let f (g : (implicit M : T) -> M.t -> unit) () = ();;
+let f (g : {M : T} -> M.t -> unit) () = ();;
 
 (* OK *)
-let f (implicit M : T) (implicit N : T) = N.x;;
+let f {M : T} {N : T} = N.x;;

--- a/testsuite/tests/typing-modular_implicits/monad.ml
+++ b/testsuite/tests/typing-modular_implicits/monad.ml
@@ -4,9 +4,9 @@ module type Monad = sig
   val bind : 'a t -> ('a -> 'b t) -> 'b t
 end;;
 
-let return (implicit M : Monad) x = M.return x;;
+let return {M : Monad} x = M.return x;;
 
-let (>>=) (implicit M : Monad) m k = M.bind m k;;
+let (>>=) {M : Monad} m k = M.bind m k;;
 
 implicit module ListMonad = struct
   type 'a t = 'a list
@@ -38,8 +38,8 @@ let m = [1; 2; 3] >>= fun x -> return x;;
 let n = return 5 >>= fun x -> [x; 2; 3];;
 
 (* Various implementations of sequence to test the handling of recursion *)
-let rec sequence : (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
-  fun (implicit M : Monad) (x : 'a M.t list) ->
+let rec sequence : {M : Monad} -> 'a M.t list -> 'a list M.t =
+  fun {M : Monad} (x : 'a M.t list) ->
     match x with
     | [] -> (return [] : 'a list M.t)
     | x :: xs ->
@@ -47,8 +47,8 @@ let rec sequence : (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
         sequence xs >>= fun ys ->
           return (y :: ys);;
 
-let rec sequence : type a. (implicit M : Monad) -> a M.t list -> a list M.t =
-  fun (implicit M : Monad) (x : a M.t list) ->
+let rec sequence : type a. {M : Monad} -> a M.t list -> a list M.t =
+  fun {M : Monad} (x : a M.t list) ->
     match x with
     | [] -> (return [] : a list M.t)
     | x :: xs ->
@@ -56,8 +56,8 @@ let rec sequence : type a. (implicit M : Monad) -> a M.t list -> a list M.t =
         sequence xs >>= fun ys ->
           return (y :: ys);;
 
-let rec sequence : (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
-  fun (implicit M : Monad) x ->
+let rec sequence : {M : Monad} -> 'a M.t list -> 'a list M.t =
+  fun {M : Monad} x ->
     match x with
     | [] -> return []
     | x :: xs ->
@@ -65,8 +65,8 @@ let rec sequence : (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
         sequence xs >>= fun ys ->
           return (y :: ys);;
 
-let rec sequence : 'a. (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
-  fun (implicit M : Monad) x ->
+let rec sequence : 'a. {M : Monad} -> 'a M.t list -> 'a list M.t =
+  fun {M : Monad} x ->
     match x with
     | [] -> return []
     | x :: xs ->
@@ -74,8 +74,8 @@ let rec sequence : 'a. (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
         sequence xs >>= fun ys ->
           return (y :: ys);;
 
-let rec sequence : type a. (implicit M : Monad) -> a M.t list -> a list M.t =
-  fun (implicit M : Monad) x ->
+let rec sequence : type a. {M : Monad} -> a M.t list -> a list M.t =
+  fun {M : Monad} x ->
     match x with
     | [] -> return []
     | x :: xs ->
@@ -83,8 +83,8 @@ let rec sequence : type a. (implicit M : Monad) -> a M.t list -> a list M.t =
         sequence xs >>= fun ys ->
           return (y :: ys);;
 
-let rec sequence : (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
-  fun (implicit M : Monad) x ->
+let rec sequence : {M : Monad} -> 'a M.t list -> 'a list M.t =
+  fun {M : Monad} x ->
     match x with
     | [] -> M.return []
     | x :: xs ->
@@ -92,8 +92,8 @@ let rec sequence : (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
         M.bind (sequence xs) (fun ys ->
           M.return (y :: ys)));;
 
-let rec sequence : 'a. (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
-  fun (implicit M : Monad) x ->
+let rec sequence : 'a. {M : Monad} -> 'a M.t list -> 'a list M.t =
+  fun {M : Monad} x ->
     match x with
     | [] -> M.return []
     | x :: xs ->
@@ -101,8 +101,8 @@ let rec sequence : 'a. (implicit M : Monad) -> 'a M.t list -> 'a list M.t =
         M.bind (sequence xs) (fun ys ->
           M.return (y :: ys)));;
 
-let rec sequence : type a. (implicit M : Monad) -> a M.t list -> a list M.t =
-  fun (implicit M : Monad) x ->
+let rec sequence : type a. {M : Monad} -> a M.t list -> a list M.t =
+  fun {M : Monad} x ->
     match x with
     | [] -> M.return []
     | x :: xs ->

--- a/testsuite/tests/typing-modular_implicits/multiple_implicits.ml
+++ b/testsuite/tests/typing-modular_implicits/multiple_implicits.ml
@@ -2,6 +2,6 @@
 module type T = sig type a end
 ;;
 
-let f : (implicit A: T) -> (implicit B: T) -> A.a * B.a -> unit =
-  fun (implicit A : T) (implicit B : T) (x : A.a * B.a) -> ()
+let f : {A: T} -> {B: T} -> A.a * B.a -> unit =
+  fun {A : T} {B : T} (x : A.a * B.a) -> ()
 ;;

--- a/testsuite/tests/typing-modular_implicits/multiple_implicits.ml.reference
+++ b/testsuite/tests/typing-modular_implicits/multiple_implicits.ml.reference
@@ -1,4 +1,4 @@
 
 #     module type T = sig type a end
-#       val f : (implicit A : T) -> (implicit B : T) -> A.a * B.a -> unit = <fun>
+#       val f : {A : T} -> {B : T} -> A.a * B.a -> unit = <fun>
 # 

--- a/testsuite/tests/typing-modular_implicits/multiple_implicits.ml.result
+++ b/testsuite/tests/typing-modular_implicits/multiple_implicits.ml.result
@@ -1,4 +1,4 @@
 
 #     module type T = sig type a end
-#       val f : (implicit A : T) -> (implicit B : T) -> A.a * B.a -> unit = <fun>
+#       val f : {A : T} -> {B : T} -> A.a * B.a -> unit = <fun>
 # 

--- a/testsuite/tests/typing-modular_implicits/number.ml
+++ b/testsuite/tests/typing-modular_implicits/number.ml
@@ -30,7 +30,7 @@ let x = 1 + 4 + 5 / 5;;
 
 let y = 1.2 + 4.4 + 5.9 / 6.2;;
 
-let sq (implicit N : Num) (x : N.t) = x * x;;
+let sq {N : Num} (x : N.t) = x * x;;
 
 let a = sq 4.9;;
 

--- a/testsuite/tests/typing-modular_implicits/show.ml
+++ b/testsuite/tests/typing-modular_implicits/show.ml
@@ -3,9 +3,9 @@ module type Show = sig
   val show : t -> string
 end;;
 
-let show (implicit S : Show) x = S.show x;;
+let show {S : Show} x = S.show x;;
 
-let print (implicit S : Show) (x : S.t) =
+let print {S : Show} (x : S.t) =
   print_endline (show x);;
 
 implicit module ShowString = struct
@@ -23,12 +23,12 @@ print_endline (show "4");;
 print 5;;
 
 
-implicit functor StringifyPair (A : Show) (B : Show) = struct
+implicit module StringifyPair {A : Show} {B : Show} = struct
   type t = A.t * B.t
   let show (a,b) = "(" ^ A.show a ^ "," ^ B.show b ^ ")"
 end;;
 
-implicit functor StringifyList (X : Show) = struct
+implicit module StringifyList {X : Show} = struct
   type t = X.t list
   let show xs = "[" ^ String.concat "; " (List.map X.show xs) ^ "]"
 end

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -180,8 +180,7 @@ and print_out_type_1 ppf =
       pp_close_box ppf ()
   | Otyp_implicit_arrow (lab, ty1, ty2) ->
       pp_open_box ppf 0;
-      pp_print_string ppf "(implicit";
-      pp_print_space ppf ();
+      pp_print_string ppf "{";
       pp_print_string ppf lab;
       pp_print_space ppf ();
       pp_print_string ppf ":";
@@ -199,7 +198,7 @@ and print_out_type_1 ppf =
         fprintf ppf "@]"
       | ty1 -> print_out_type_2 ppf ty1;
       end;
-      pp_print_string ppf ") ->";
+      pp_print_string ppf "} ->";
       pp_print_space ppf ();
       print_out_type_1 ppf ty2;
       pp_close_box ppf ()
@@ -380,7 +379,7 @@ let rec print_out_functor ppf =
 and print_out_implicit_functor n ppf =
   function
   | Omty_functor (name , Some mty_arg, mty_res) when n > 0 ->
-      fprintf ppf "(%s : %a) %a" name
+      fprintf ppf "{%s : %a} %a" name
         print_out_module_type mty_arg
         (print_out_implicit_functor (n - 1)) mty_res
     (* The implicit declares 'n' parameters, but when printing module_type
@@ -460,11 +459,10 @@ and print_out_sig_item ppf =
                      | Orec_next -> "and")
         name !out_module_type mty
   | Osig_module (name, mty, rs, Asttypes.Implicit n) ->
-      fprintf ppf "@[<2>%s %s %s %a@]"
+      fprintf ppf "@[<2>%s module %s %a@]"
         (match rs with Orec_not -> "implicit"
                      | Orec_first -> "implicit rec"
                      | Orec_next -> "and")
-        (if n = 0 then "module" else "functor")
         name
         (print_out_implicit_functor n) mty
   | Osig_type(td, rs) ->


### PR DESCRIPTION
Change the syntax for implicit parameters (in both functions and implicit functors) from:

``` ocaml
(implicit M : Monad) -> t
```

to:

``` ocaml
{M : Monad} -> t
```

for the sake of brevity. This addresses #13.
