### PR TITLE
Travis tests: use Camlp4 branch with modular implicits support.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -9,18 +9,7 @@ i386)
   (cd camlp4                              \
    && git checkout modular-implicits-4.02 \
    && ./configure                         \
-   && make                                \
-   && sudo make install)
-
-  git clone git://github.com/ocaml/opam
-  (cd opam                                \
-   && ./configure                         \
-   && make lib-ext                        \
-   && make                                \
-   && sudo make install)
-
-  opam init -y -a git://github.com/ocaml/opam-repository
-  opam install -y utop
+   && make)
   ;;
 *)
   echo unknown arch

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -4,10 +4,21 @@ i386)
   make world.opt
   sudo make install
   cd testsuite && make all
-  git clone git://github.com/ocaml/camlp4
-  cd camlp4 && ./configure && make && sudo make install
+
+  git clone git://github.com/ocamllabs/camlp4
+  (cd camlp4                              \
+   && git checkout modular-implicits-4.02 \
+   && ./configure                         \
+   && make                                \
+   && sudo make install)
+
   git clone git://github.com/ocaml/opam
-  cd opam && ./configure && make lib-ext && make && sudo make install
+  (cd opam                                \
+   && ./configure                         \
+   && make lib-ext                        \
+   && make                                \
+   && sudo make install)
+
   opam init -y -a git://github.com/ocaml/opam-repository
   opam install -y utop
   ;;


### PR DESCRIPTION
Travis: the compiler, testsuite and camlp4 are now working.  The step that builds OPAM fails because of [this line](https://github.com/ocaml/opam/blob/cbd768ab3ce1c12d4151301649466b23be0e9d64/src/solver/opamHeuristic.ml#L394) in the OPAM source:

``` ocaml
    let implicit =
```
